### PR TITLE
add option to enable lifetime markers

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -190,6 +190,7 @@ public:
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
   bool ForceZeroStoreLifetimes = false; // OPT_force_zero_store_lifetimes
+  bool EnableLifetimeMarkers = false; // OPT_enable_lifetime_markers
 
   // Optimization pass enables, disables and selects
   std::map<std::string, bool> DxcOptimizationToggles; // OPT_opt_enable & OPT_opt_disable

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -273,6 +273,8 @@ def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>
   HelpText<"Print LLVM IR after each pass.">;
 def force_zero_store_lifetimes : Flag<["-", "/"], "force-zero-store-lifetimes">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Instead of generating lifetime intrinsics (SM >= 6.6) or storing undef (SM < 6.6), force fall back to storing zeroinitializer.">;
+def enable_lifetime_markers : Flag<["-", "/"], "enable-lifetime-markers">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+  HelpText<"Enable generation of lifetime markers">;
 
 // Used with API only
 def skip_serialization : Flag<["-", "/"], "skip-serialization">, Group<hlslcore_Group>, Flags<[CoreOption, HelpHidden]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -642,6 +642,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.ResMayAlias = Args.hasFlag(OPT_res_may_alias, OPT_INVALID, false);
   opts.ResMayAlias = Args.hasFlag(OPT_res_may_alias_, OPT_INVALID, opts.ResMayAlias);
   opts.ForceZeroStoreLifetimes = Args.hasFlag(OPT_force_zero_store_lifetimes, OPT_INVALID, false);
+  opts.EnableLifetimeMarkers = Args.hasFlag(OPT_enable_lifetime_markers, OPT_INVALID,
+                                            DXIL::CompareVersions(Major, Minor, 6, 6) >= 0);
 
   if (opts.DefaultColMajor && opts.DefaultRowMajor) {
     errors << "Cannot specify /Zpr and /Zpc together, use /? to get usage information";

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -230,6 +230,8 @@ public:
   bool HLSLPrintAfterAll = false;
   /// Force-replace lifetime intrinsics by zeroinitializer stores.
   bool HLSLForceZeroStoreLifetimes = false;
+  /// Enable lifetime marker generation
+  bool HLSLEnableLifetimeMarkers = false;
   // HLSL Change Ends
 
   // SPIRV Change Starts

--- a/tools/clang/lib/CodeGen/CGDecl.cpp
+++ b/tools/clang/lib/CodeGen/CGDecl.cpp
@@ -874,6 +874,12 @@ llvm::Value *CodeGenFunction::EmitLifetimeStart(uint64_t Size,
   if (CGM.getCodeGenOpts().OptimizationLevel == 0)
     return nullptr;
 
+  // HLSL Change Begins
+  // Don't emit the intrinsic for hlsl for now unless it is explicitly enabled
+  if (!CGM.getCodeGenOpts().HLSLEnableLifetimeMarkers)
+    return nullptr;
+  // HLSL Change Ends
+
   // Disable lifetime markers in msan builds.
   // FIXME: Remove this when msan works with lifetime markers.
   if (getLangOpts().Sanitize.has(SanitizerKind::Memory))
@@ -888,6 +894,11 @@ llvm::Value *CodeGenFunction::EmitLifetimeStart(uint64_t Size,
 }
 
 void CodeGenFunction::EmitLifetimeEnd(llvm::Value *Size, llvm::Value *Addr) {
+  // HLSL Change Begins
+  // Don't emit the intrinsic for hlsl for now unless it is explicitly enabled
+  if (!CGM.getCodeGenOpts().HLSLEnableLifetimeMarkers)
+    return;
+  // HLSL Change Ends
   Addr = Builder.CreateBitCast(Addr, Int8PtrTy);
   llvm::CallInst *C =
       Builder.CreateCall(CGM.getLLVMLifetimeEndFn(), {Size, Addr});

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -5685,7 +5685,8 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
     }
 
     // save to generate lifetime end after call
-    lifetimeCleanupList.emplace_back(tmpLV);
+    if (CGM.getCodeGenOpts().HLSLEnableLifetimeMarkers)
+      lifetimeCleanupList.emplace_back(tmpLV);
 
     // cast before the call
     if (Param->isModifierIn() &&

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/dbg_value_phi_loop.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/dbg_value_phi_loop.hlsl
@@ -10,19 +10,19 @@
 // CHECK: call void @llvm.dbg.value(metadata float
 // CHECK: call void @llvm.dbg.value(metadata float
 // CHECK: call void @llvm.dbg.value(metadata float
+// CHECK: fmul
+// CHECK: fmul
+// CHECK: fmul
+// CHECK: fmul
+// CHECK: call void @llvm.dbg.value(metadata float
+// CHECK: call void @llvm.dbg.value(metadata float
+// CHECK: call void @llvm.dbg.value(metadata float
+// CHECK: call void @llvm.dbg.value(metadata float
 
 // CHECK: phi float [
 // CHECK: phi float [
 // CHECK: phi float [
 // CHECK: phi float [
-// CHECK: call void @llvm.dbg.value(metadata float
-// CHECK: call void @llvm.dbg.value(metadata float
-// CHECK: call void @llvm.dbg.value(metadata float
-// CHECK: call void @llvm.dbg.value(metadata float
-// CHECK: fmul
-// CHECK: fmul
-// CHECK: fmul
-// CHECK: fmul
 // CHECK: call void @llvm.dbg.value(metadata float
 // CHECK: call void @llvm.dbg.value(metadata float
 // CHECK: call void @llvm.dbg.value(metadata float

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_lib_6_3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_lib_6_3.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_3 %s  | FileCheck %s
+// RUN: %dxc -T lib_6_3 -enable-lifetime-markers %s  | FileCheck %s
 
 // This file is identical to lifetimes.hlsl except that it tests for
 // undef stores instead of lifetime intrinsics (fallback for earlier

--- a/tools/clang/test/HLSLFileCheck/passes/hl/sroa_hlsl/memcpy_domuser.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/sroa_hlsl/memcpy_domuser.hlsl
@@ -9,8 +9,8 @@
 // CHECK-NOT: memcpy
 // CHECK-NOT: = br
 // CHECK: icmp slt i32
-// CHECK: br i1
 // CHECK: icmp sgt i32
+// CHECK: and i1
 // CHECK: br i1
 // CHECK: cbufferLoadLegacy
 // CHECK: fadd

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/MotionBlurFinalPassCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/MotionBlurFinalPassCS.hlsl
@@ -3,9 +3,9 @@
 // CHECK: threadId
 // CHECK: Sqrt
 // CHECK: FMin
+// CHECK: sampleLevel
+// CHECK: sampleLevel
 // CHECK: Round_pi
-// CHECK: sampleLevel
-// CHECK: sampleLevel
 // CHECK: sampleLevel
 // CHECK: sampleLevel
 

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/MotionBlurFinalPassTemporalCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/MotionBlurFinalPassTemporalCS.hlsl
@@ -3,9 +3,9 @@
 // CHECK: threadId
 // CHECK: Sqrt
 // CHECK: FMin
+// CHECK: sampleLevel
+// CHECK: sampleLevel
 // CHECK: Round_pi
-// CHECK: sampleLevel
-// CHECK: sampleLevel
 // CHECK: sampleLevel
 // CHECK: sampleLevel
 // CHECK: sampleLevel

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1147,6 +1147,7 @@ public:
     compiler.getCodeGenOpts().MainFileName = pMainFile;
     compiler.getCodeGenOpts().HLSLPrintAfterAll = Opts.PrintAfterAll;
     compiler.getCodeGenOpts().HLSLForceZeroStoreLifetimes = Opts.ForceZeroStoreLifetimes;
+    compiler.getCodeGenOpts().HLSLEnableLifetimeMarkers = Opts.EnableLifetimeMarkers;
 
     // Translate signature packing options
     if (Opts.PackPrefixStable)


### PR DESCRIPTION
The option defaults to enabled for 6.6 and disabled for all else.